### PR TITLE
Fix undefined RNAppStoreReview on iOS

### DIFF
--- a/src/index.ios.js
+++ b/src/index.ios.js
@@ -6,7 +6,7 @@ class AppStoreReview {
 
   static requestReview(appIdentifier) {
     if (!RNAppStoreReview) {
-      console.error('RNAppStoreReview library seems to be not linked to your project...');
+      return console.error('RNAppStoreReview library seems to be not linked to your project...');
     }
     return RNAppStoreReview.requestReview(appIdentifier);
   }


### PR DESCRIPTION
If RNAppStoreREview is not defined, it will throw an error.