### PR TITLE
Change include priority

### DIFF
--- a/ios/RNAppStoreReview.h
+++ b/ios/RNAppStoreReview.h
@@ -8,10 +8,10 @@
 #ifndef AppRate_h
 #define AppRate_h
 
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
 #endif
 
 #import <StoreKit/StoreKit.h>


### PR DESCRIPTION
Relate to facebook/react-native#15775

Current include order crashes on latest react native (v0.48.0).