### PR TITLE
runtime error for appstorereview

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,19 @@ And if your user got an iOS version lesser than 8.0, it will be redirected on th
 
 ### Mostly automatic installation
 
-`$ react-native link react-native-app-store-review`
+```
+cd ios
+```
+
+Add this line to ios/Podfile
+```
+  pod 'RNAppStoreReview', :path => '../node_modules/react-native-app-store-review'
+```
+
+Run this
+```
+pod install
+```
 
 ### Manual installation
 

--- a/RNAppStoreReview.podspec
+++ b/RNAppStoreReview.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author             = { "author" => "jeremy.magrin@gmail.com" }
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/magrinj/react-native-app-store-review.git", :tag => "master" }
-  s.source_files  = "RNAppStoreReview/**/*.{h,m}"
+  s.source_files  = "ios/**/*.{h,m}"
   s.requires_arc = true
 
 

--- a/RNAppStoreReview.podspec
+++ b/RNAppStoreReview.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNAppStoreReview"
-  s.version      = "0.0.4"
+  s.version      = "0.0.5"
   s.summary      = "RNAppStoreReview"
   s.description  = <<-DESC
                   Rate on app store inside your app

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-app-store-review",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Rate on app store inside your app",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Closes #15 

This is because RNAppStoreReview is not getting added to the build -
it's not appearing in the Library search paths and ldflags via
Pods/*.xcconfig

Looking into this it's because the podspec file in not in the root
directory and the sources property is referencing a path that does not
exist. Too bad pod install doesn't alert us to this problem!

Moved the podspec to root.

changed:
s.source_files  = "RNAppStoreReview/**/*.{h,m}"
To:
s.source_files  = "ios/**/*.{h,m}"

Updated readme + bumped version
